### PR TITLE
netlink: xfrm, add optional field to XfrmPolicyTmpl

### DIFF
--- a/xfrm_policy.go
+++ b/xfrm_policy.go
@@ -58,12 +58,13 @@ func (a PolicyAction) String() string {
 // policy. These rules are matched with XfrmState to determine encryption
 // and authentication algorithms.
 type XfrmPolicyTmpl struct {
-	Dst   net.IP
-	Src   net.IP
-	Proto Proto
-	Mode  Mode
-	Spi   int
-	Reqid int
+	Dst      net.IP
+	Src      net.IP
+	Proto    Proto
+	Mode     Mode
+	Spi      int
+	Reqid    int
+	Optional int
 }
 
 func (t XfrmPolicyTmpl) String() string {

--- a/xfrm_policy_linux.go
+++ b/xfrm_policy_linux.go
@@ -78,6 +78,7 @@ func (h *Handle) xfrmPolicyAddOrUpdate(policy *XfrmPolicy, nlProto int) error {
 		userTmpl.XfrmId.Proto = uint8(tmpl.Proto)
 		userTmpl.XfrmId.Spi = nl.Swap32(uint32(tmpl.Spi))
 		userTmpl.Mode = uint8(tmpl.Mode)
+		userTmpl.Optional = uint8(tmpl.Optional)
 		userTmpl.Reqid = uint32(tmpl.Reqid)
 		userTmpl.Aalgos = ^uint32(0)
 		userTmpl.Ealgos = ^uint32(0)


### PR DESCRIPTION
Add optional field in XfrmPolicyTmpl to template code so users can
configure template optional values.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>